### PR TITLE
Add phpinfo and configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Vulnerability: Hidden File Sample
 - Vulnerability: JSP Samples Page
 - Vulnerability: Exposed Panels - CrushFTP
+- Vulnerability: Publicly accessible phpinfo & php configuration files
 - GIF Favicon
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ docker-compose up
 - JSP Samples Page
 - Exposed Panels - CrushFTP
 - Default Admin Login - Apache Axis2
+- Publicly accessible phpinfo & php configuration files

--- a/public/php.ini
+++ b/public/php.ini
@@ -1,0 +1,15 @@
+[PHP]
+; This is a sample file
+;;;;;;;;;;;;;;;;;;;
+; About php.ini   ;
+;;;;;;;;;;;;;;;;;;;
+; PHP's initialization file, generally called php.ini, is responsible for
+; configuring many of the aspects of PHP's behavior.
+; Name for user-defined php.ini (.htaccess) files. Default is ".user.ini"
+user_ini.filename = ".user.ini"
+
+; TTL for user-defined php.ini files (time-to-live) in seconds. Default is 300 seconds (5 minutes)
+user_ini.cache_ttl = 300
+
+; http://php.net/engine
+engine = On

--- a/public/phpinfo.php
+++ b/public/phpinfo.php
@@ -1,0 +1,4 @@
+<?php
+// Intentionally exposed phpinfo
+phpinfo()
+?>

--- a/public/user.ini
+++ b/public/user.ini
@@ -1,0 +1,3 @@
+# Sample File
+upload_max_filesize = 200M
+post_max_size = 200M


### PR DESCRIPTION
Publicly accessible phpinfo and php.ini. This should not be allowed to be served publicly.